### PR TITLE
Resolve bug #5 by adding missing include paths in the release target.

### DIFF
--- a/software/ATSAMR34_RN_PARSER_MLS_1_0_P_5/APPS_ENDDEVICE_DEMO1/APPS_ENDDEVICE_DEMO1.cproj
+++ b/software/ATSAMR34_RN_PARSER_MLS_1_0_P_5/APPS_ENDDEVICE_DEMO1/APPS_ENDDEVICE_DEMO1.cproj
@@ -524,6 +524,8 @@
       <Value>../src/ASF/sam0/drivers/adc/adc_sam_l_c</Value>
       <Value>../src/ASF/thirdparty/wireless/lorawan/services/edbg_eui</Value>
       <Value>../src/config</Value>
+      <Value>../src/parser</Value>
+      <Value>../src/parser/inc</Value>
     </ListValues>
   </armgcc.compiler.directories.IncludePaths>
   <armgcc.compiler.optimization.level>Optimize for size (-Os)</armgcc.compiler.optimization.level>


### PR DESCRIPTION
Correct the build configuration flaw in the release target of the ATSAMR34_RN_PARSER_MLS_1_0_P_5 project by adding the missing paths.