### PR TITLE
Work around bug #7 by adding a hack to force EDBG building in release.

### DIFF
--- a/software/ATSAMR34_RN_PARSER_MLS_1_0_P_5/APPS_ENDDEVICE_DEMO1/APPS_ENDDEVICE_DEMO1.cproj
+++ b/software/ATSAMR34_RN_PARSER_MLS_1_0_P_5/APPS_ENDDEVICE_DEMO1/APPS_ENDDEVICE_DEMO1.cproj
@@ -444,7 +444,7 @@
       <Value>JPN_BAND=1</Value>
       <Value>AS_BAND=1</Value>
       <Value>RANDOM_NW_ACQ=1</Value>
-      <Value>EDBG_EUI_READ=0</Value>
+      <Value>EDBG_EUI_READ=1</Value>
       <Value>__SAMR34J18B__</Value>
       <Value>CERT_APP=1</Value>
       <Value>CONF_PMM_ENABLE</Value>


### PR DESCRIPTION
Partially correct the build configuration flaw in the release target of the ATSAMR34_RN_PARSER_MLS_1_0_P_5 project by forcing to build using EDBG constructs.

I believe the real solution to this problem is to conditionally use EDBG code. Any code depending on EDBG should be enclosed in:

```
#if defined (EDBG_EUI_READ=1)
#endif
```

Therefore, this hack is a work around the problem rather than a solution. Feel free to reject the request for this reason.